### PR TITLE
Change FinNat to use inductive leq

### DIFF
--- a/theories/Spaces/Finite/FinNat.v
+++ b/theories/Spaces/Finite/FinNat.v
@@ -11,21 +11,15 @@ Local Open Scope nat_scope.
 Definition FinNat (n : nat) : Type := {x : nat | x < n}.
 
 Definition zero_finnat (n : nat) : FinNat n.+1
-  := (0; leq_1_Sn ).
+  := (0; leq_1_Sn).
 
 Lemma path_zero_finnat (n : nat) (h : 0 < n.+1) : zero_finnat n = (0; h).
 Proof.
   by apply path_sigma_hprop.
 Defined.
 
-Definition succ_finnat {n : nat} (u : FinNat n) : FinNat n.+1.
-Proof.
-  exists u.1.+1.
-  pose u.2 as l; cbn in l.
-  by rapply leq_S_n'.
-Defined.
-  
-(*   := (u.1.+1; leq_S_n' _ _ u.2). *)
+Definition succ_finnat {n : nat} (u : FinNat n) : FinNat n.+1
+  := (u.1.+1; leq_S_n' u.1.+1 n u.2).
 
 Lemma path_succ_finnat {n : nat} (u : FinNat n) (h : u.1.+1 < n.+1)
   : succ_finnat u = (u.1.+1; h).
@@ -33,11 +27,8 @@ Proof.
   by apply path_sigma_hprop.
 Defined.
 
-Definition last_finnat (n : nat) : FinNat n.+1.
-Proof.
-  exists n.
-  exact _.
-Defined.
+Definition last_finnat (n : nat) : FinNat n.+1
+  := exist (fun x => x < n.+1) n (leq_refl n.+1).
 
 Lemma path_last_finnat (n : nat) (h : n < n.+1)
   : last_finnat n = (n; h).
@@ -45,12 +36,8 @@ Proof.
   by apply path_sigma_hprop.
 Defined.
 
-Definition incl_finnat {n : nat} (u : FinNat n) : FinNat n.+1.
-Proof.
-  destruct u as [u1 u2].
-  exists u1.
-  rapply transitivity.
-Defined.
+Definition incl_finnat {n : nat} (u : FinNat n) : FinNat n.+1
+  := (u.1; leq_trans u.2 (leq_S n n (leq_n n))).
 
 Lemma path_incl_finnat (n : nat) (u : FinNat n) (h : u.1 < n.+1)
   : incl_finnat u = (u.1; h).
@@ -65,8 +52,7 @@ Definition finnat_ind (P : forall n : nat, FinNat n -> Type)
   : P n u.
 Proof.
   induction n as [| n IHn].
-  - pose u.2 as u'.
-    inversion u'.
+  - elim (not_lt_n_0 u.1 u.2).
   - destruct u as [x h].
     destruct x as [| x].
     + exact (transport (P n.+1) (path_zero_finnat _ h) (z _)).
@@ -80,10 +66,7 @@ Lemma compute_finnat_ind_zero (P : forall n : nat, FinNat n -> Type)
   (n : nat)
   : finnat_ind P z s (zero_finnat n) = z n.
 Proof.
-  simpl.
-  unfold path_zero_finnat.
-  rewrite  path_sigma_hprop_1.
-  reflexivity.
+  cbn. by induction (hset_path2 1 (path_zero_finnat n leq_1_Sn)).
 Defined.
 
 Lemma compute_finnat_ind_succ (P : forall n : nat, FinNat n -> Type)
@@ -93,7 +76,18 @@ Lemma compute_finnat_ind_succ (P : forall n : nat, FinNat n -> Type)
   {n : nat} (u : FinNat n)
   : finnat_ind P z s (succ_finnat u) = s n u (finnat_ind P z s u).
 Proof.
-Admitted.
+  refine (_ @ transport (fun p => transport _ p (s n u _)
+                             = s n u (finnat_ind P z s u))
+                   (hset_path2 1
+                    (@path_succ_finnat n u (leq_S_n' _ _ u.2))) idpath).
+  simpl.
+  destruct u as [u1 u2].
+  assert (u2 = leq_S_n u1.+1 n (leq_S_n' u1.+1 n u2)).
+  - apply path_ishprop.
+  - simpl.
+    rewrite <- X.
+    reflexivity.
+Defined.
 
 Monomorphic Definition is_bounded_fin_to_nat {n} (k : Fin n)
   : fin_to_nat k < n.
@@ -101,30 +95,24 @@ Proof.
   induction n as [| n IHn].
   - elim k.
   - destruct k as [k | []].
-    + nrapply leq_trans.
+    + apply (@leq_trans _ n _).
       * apply IHn.
-      * by apply leq_S.
-    + apply leq_n.
+      * apply leq_S. reflexivity.
+    + apply leq_refl.
 Defined.
 
 Monomorphic Definition fin_to_finnat {n} (k : Fin n) : FinNat n
   := (fin_to_nat k; is_bounded_fin_to_nat k).
 
-Monomorphic Fixpoint finnat_to_fin {n : nat} : FinNat n -> Fin n.
-Proof.
-  destruct n.
-  { intros u.
-    contradiction (not_leq_Sn_0 _ u.2). }
-  intros u.
-  destruct u as [u p].  
-  destruct u as [|u].
-  1: exact fin_zero.
-  apply fsucc.
-  apply finnat_to_fin.
-  exists u.
-  apply leq_S_n in p.
-  assumption.
-Defined.
+Monomorphic Fixpoint finnat_to_fin {n : nat} : FinNat n -> Fin n
+  := match n with
+     | 0 => fun u => Empty_rec (not_lt_n_0 _ u.2)
+     | n.+1 => fun u =>
+        match u with
+        | (0; _) => fin_zero
+        | (x.+1; h) => fsucc (finnat_to_fin (x; leq_S_n _ _ h))
+        end
+     end.
 
 Lemma path_fin_to_finnat_fsucc {n : nat} (k : Fin n)
   : fin_to_finnat (fsucc k) = succ_finnat (fin_to_finnat k).
@@ -155,18 +143,7 @@ Defined.
 Lemma path_finnat_to_fin_succ {n : nat} (u : FinNat n)
   : finnat_to_fin (succ_finnat u) = fsucc (finnat_to_fin u).
 Proof.
-  destruct u as [u p].
-  induction p.
-  1: reflexivity.
-  destruct u.
-  1: reflexivity.
-  simpl.
-  refine (ap (fun x =>
-    match fsucc (finnat_to_fin (u; x)) with
-    | inl i' => inl (fsucc i')
-    | inr tt => inr tt
-    end) _).
-  apply path_ishprop.
+  cbn. do 2 f_ap. by apply path_sigma_hprop.
 Defined.
 
 Lemma path_finnat_to_fin_zero (n : nat)
@@ -179,17 +156,14 @@ Lemma path_finnat_to_fin_incl {n : nat} (u : FinNat n)
   : finnat_to_fin (incl_finnat u) = fin_incl (finnat_to_fin u).
 Proof.
   induction n as [| n IHn].
-  - pose u.2 as p; inversion p.
+  - elim (not_lt_n_0 _ u.2).
   - destruct u as [x h].
     destruct x as [| x]; [reflexivity|].
-    simpl.
-    srefine ((ap _ (ap _ (path_succ_finnat (x; _) _)))^ @ _).
-    1: hnf; by apply leq_S_n.
-    simpl.
-    unfold fin_incl.
-    
-    refine (ap fsucc (IHn (x; _))).
-Admitted.
+    refine ((ap _ (ap _ (path_succ_finnat (x; leq_S_n _ _ h) h)))^ @ _).
+    refine (_ @ ap fsucc (IHn (x; leq_S_n _ _ h))).
+    rewrite <- path_finnat_to_fin_succ.
+    reflexivity.
+Defined.
 
 Lemma path_finnat_to_fin_last (n : nat)
   : finnat_to_fin (last_finnat n) = fin_last.
@@ -203,16 +177,14 @@ Lemma path_finnat_to_fin_to_finnat {n : nat} (u : FinNat n)
   : fin_to_finnat (finnat_to_fin u) = u.
 Proof.
   induction n as [| n IHn].
-  - pose u.2 as p; inversion p.
+  - elim (not_lt_n_0 _ u.2).
   - destruct u as [x h].
     destruct x as [| x].
-    + destruct h.
-(*       apply path_fin_to_finnat_fin_zero.
+    + rewrite path_fin_to_finnat_fin_zero. by apply path_sigma_hprop.
     + apply path_sigma_hprop.
       refine ((path_fin_to_finnat_fsucc _)..1 @ _).
-      exact (ap S (IHn (x; h))..1). *)
-(* Defined. *)
-Admitted.
+      exact (ap S (IHn (x; leq_S_n _ _ h))..1).
+Defined.
 
 Lemma path_fin_to_finnat_to_fin {n : nat} (k : Fin n)
   : finnat_to_fin (fin_to_finnat k) = k.


### PR DESCRIPTION
I have updated FinNat.v, so it type checks now, but without much thought. Are you sure the inductive `leq` is preferable?