### PR TITLE
Diagnose bad coercion

### DIFF
--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -461,6 +461,7 @@ Definition connecting_map {F X Y}
   : loops Y ->* F
   := i_fiberseq (connect_fiberseq i f).
 
+Set Printing Coercions.
 Global Instance isexact_connect_R {F X Y}
   (i : F ->* X) (f : X ->* Y) `{IsExact purely F X Y i f}
   : IsExact purely (fmap loops f) (connecting_map i f).
@@ -472,6 +473,7 @@ Proof.
            (pequiv_pfiber _ _ (square_pequiv_pfiber _ _ (square_pfib_pequiv_cxfib i f))))^-1*)
           (((pfiber2_loops f) o*E (pequiv_pfiber _ _ (square_pfib_pequiv_cxfib i f)))^-1*)
           _ (pfib i)).
+(** @todo: this proof hangs on Defined when the method cate_fun is directly declared as a coercion CatEquiv >-> Hom *)
   refine (vinverse 
             ((loops_inv X) o*E
              (pfiber2_loops (pfib f)) o*E

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -17,11 +17,11 @@ Class DHasEquivs {A : Type} `{HasEquivs A}
     DCatEquiv f a' b' -> DHom f a' b';
   dcate_isequiv : forall {a b} {f : a $<~> b} {a'} {b'}
     (f' : DCatEquiv f a' b'), DCatIsEquiv (dcate_fun f');
-  dcate_buildequiv : forall {a b} {f : a $-> b} `{!CatIsEquiv f} {a'} {b'}
+  dcate_buildequiv : forall {a b} {f : a $-> b} {fe : CatIsEquiv f} {a'} {b'}
     (f' : DHom f a' b') {fe' : DCatIsEquiv f'},
-    DCatEquiv (Build_CatEquiv f) a' b';
-  dcate_buildequiv_fun : forall {a b} {f : a $-> b} `{!CatIsEquiv f}
-    {a'} {b'} (f' : DHom f a' b') {fe' : DCatIsEquiv f'},
+    DCatEquiv (Build_CatEquiv (fe:=fe) f) a' b';
+  dcate_buildequiv_fun : forall {a b} {f : a $-> b} {fe : CatIsEquiv f}
+    {a'} {b'} (f' : DHom f a' b') {fe' : DCatIsEquiv (fe:=fe) f'},
     DGpdHom (cate_buildequiv_fun f)
     (dcate_fun (dcate_buildequiv f' (fe':=fe'))) f';
   dcate_inv' : forall {a b} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
@@ -44,8 +44,8 @@ Global Existing Instance dcate_isequiv.
 Coercion dcate_fun : DCatEquiv >-> DHom.
 
 Definition Build_DCatEquiv {A} {D : A -> Type} `{DHasEquivs A D}
-  {a b : A} {f : a $-> b} `{!CatIsEquiv f} {a' : D a} {b' : D b}
-  (f' : DHom f a' b') {fe' : DCatIsEquiv f'}
+  {a b : A} {f : a $-> b} {fe : CatIsEquiv f} {a' : D a} {b' : D b}
+  (f' : DHom f a' b') {fe' : DCatIsEquiv (fe:=fe) f'}
   : DCatEquiv (Build_CatEquiv f) a' b'
   := dcate_buildequiv f' (fe':=fe').
 
@@ -142,7 +142,7 @@ Proof.
   snrapply Build_HasEquivs.
   1:{ intros [a a'] [b b']. exact {f : a $<~> b & DCatEquiv f a' b'}. }
   all: intros aa' bb' [f f'].
-  - exact {fe : CatIsEquiv f & DCatIsEquiv f'}.
+  - exact {fe : CatIsEquiv f & DCatIsEquiv (fe:=fe) f'}.
   - exists f. exact f'.
   - exact (cate_isequiv f; dcate_isequiv f').
   - intros [fe fe'].

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -12,31 +12,29 @@ Declare Scope wc_iso_scope.
 
 Class HasEquivs (A : Type) `{Is1Cat A} :=
 {
-  CatEquiv' : A -> A -> Type where "a $<~> b" := (CatEquiv' a b);
+  CatEquiv : A -> A -> Type where "a $<~> b" := (CatEquiv a b);
   CatIsEquiv : forall a b, (a $-> b) -> Type;
   cate_fun' : forall a b, (a $<~> b) -> (a $-> b);
   cate_isequiv : forall a b (f : a $<~> b), CatIsEquiv a b (cate_fun' a b f);
-  cate_buildequiv' : forall a b (f : a $-> b), CatIsEquiv a b f -> CatEquiv' a b;
-  cate_buildequiv_fun' : forall a b (f : a $-> b) (fe : CatIsEquiv a b f),
-      cate_fun' a b (cate_buildequiv' a b f fe) $== f;
+  cate_buildequiv : forall a b (f : a $-> b), CatIsEquiv a b f -> CatEquiv a b;
+  cate_buildequiv_fun : forall a b (f : a $-> b) (fe : CatIsEquiv a b f),
+      cate_fun' a b (cate_buildequiv a b f fe) $== f;
   cate_inv' : forall a b (f : a $<~> b), b $-> a;
   cate_issect' : forall a b (f : a $<~> b),
     cate_inv' _ _ f $o cate_fun' _ _ f $== Id a;
   cate_isretr' : forall a b (f : a $<~> b),
       cate_fun' _ _ f $o cate_inv' _ _ f $== Id b;
-  catie_adjointify' : forall a b (f : a $-> b) (g : b $-> a)
+  catie_adjointify : forall a b (f : a $-> b) (g : b $-> a)
     (r : f $o g $== Id b) (s : g $o f $== Id a), CatIsEquiv a b f;
 }.
 
-Existing Class CatIsEquiv.
 Arguments CatIsEquiv {A _ _ _ _ _ a b} f.
-Global Existing Instance cate_isequiv.
 Arguments cate_isequiv {A _ _ _ _ _ a b} f.
+Arguments cate_buildequiv_fun {A _ _ _ _ _ a b} f {fe}.
+Arguments catie_adjointify {A _ _ _ _ _ a b} f g r s.
 
-(** Since apparently a field of a record can't be the source of a coercion (Coq complains about the uniform inheritance condition, although as officially stated that condition appears to be satisfied), we redefine all the fields of [HasEquivs]. *)
-
-Definition CatEquiv {A} `{HasEquivs A} (a b : A)
-  := @CatEquiv' A _ _ _ _ _ a b.
+Existing Class CatIsEquiv.
+Global Existing Instance cate_isequiv.
 
 Notation "a $<~> b" := (CatEquiv a b).
 Infix "≅" := CatEquiv : wc_iso_scope.
@@ -46,23 +44,13 @@ Definition cate_fun {A} `{HasEquivs A} {a b : A} (f : a $<~> b)
   : a $-> b
   := @cate_fun' A _ _ _ _ _ a b f.
 
+Arguments cate_fun {A _ _ _ _ _ a b} f.
 Coercion cate_fun : CatEquiv >-> Hom.
 
 Definition Build_CatEquiv {A} `{HasEquivs A} {a b : A}
            (f : a $-> b) {fe : CatIsEquiv f}
   : a $<~> b
-  := cate_buildequiv' a b f fe.
-
-Definition cate_buildequiv_fun {A} `{HasEquivs A} {a b : A}
-           (f : a $-> b) {fe : CatIsEquiv f}
-  : cate_fun (Build_CatEquiv f) $== f
-  := cate_buildequiv_fun' a b f fe.
-
-Definition catie_adjointify {A} `{HasEquivs A} {a b : A}
-           (f : a $-> b) (g : b $-> a)
-           (r : f $o g $== Id b) (s : g $o f $== Id a)
-  : CatIsEquiv f
-  := catie_adjointify' a b f g r s.
+  := cate_buildequiv a b f fe.
 
 Definition cate_adjointify {A} `{HasEquivs A} {a b : A}
            (f : a $-> b) (g : b $-> a)
@@ -87,7 +75,7 @@ Definition cate_issect {A} `{HasEquivs A} {a b} (f : a $<~> b)
 Proof.
   refine (_ $@ cate_issect' a b f).
   refine (_ $@R f).
-  apply cate_buildequiv_fun'.
+  apply cate_buildequiv_fun.
 Defined.
 
 Definition cate_isretr {A} `{HasEquivs A} {a b} (f : a $<~> b)
@@ -95,7 +83,7 @@ Definition cate_isretr {A} `{HasEquivs A} {a b} (f : a $<~> b)
 Proof.
   refine (_ $@ cate_isretr' a b f).
   refine (f $@L _).
-  apply cate_buildequiv_fun'.
+  apply cate_buildequiv_fun.
 Defined.
 
 (** If [g] is a section of an equivalence, then it is the inverse. *)

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -31,6 +31,7 @@ Class HasEquivs (A : Type) `{Is1Cat A} :=
 Existing Class CatIsEquiv.
 Arguments CatIsEquiv {A _ _ _ _ _ a b} f.
 Global Existing Instance cate_isequiv.
+Arguments cate_isequiv {A _ _ _ _ _ a b} f.
 
 (** Since apparently a field of a record can't be the source of a coercion (Coq complains about the uniform inheritance condition, although as officially stated that condition appears to be satisfied), we redefine all the fields of [HasEquivs]. *)
 

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -81,12 +81,12 @@ Section Induced_category.
     + apply CatIsEquiv.
     + apply cate_fun.
     + apply cate_isequiv.
-    + apply cate_buildequiv'.
-    + nrapply cate_buildequiv_fun'.
+    + apply Build_CatEquiv.
+    + nrapply cate_buildequiv_fun.
     + apply cate_inv'.
     + nrapply cate_issect'.
     + nrapply cate_isretr'.
-    + nrapply catie_adjointify'.
+    + nrapply catie_adjointify.
   Defined.
 
 End Induced_category.

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -163,10 +163,10 @@ Proof.
   srapply Build_HasEquivs; intros a b; unfold op in *; cbn.
   - exact (b $<~> a).
   - apply CatIsEquiv.
-  - apply cate_fun'.
+  - apply cate_fun.
   - apply cate_isequiv.
-  - apply cate_buildequiv'.
-  - rapply cate_buildequiv_fun'.
+  - apply Build_CatEquiv.
+  - rapply cate_buildequiv_fun.
   - apply cate_inv'.
   - rapply cate_isretr'.
   - rapply cate_issect'.


### PR DESCRIPTION
Related to [#1807](https://github.com/HoTT/Coq-HoTT/pull/1807).

So far I've been able to remove all the primed fields except `cate_fun'`. Declaring the method of the typeclass directly as the corecion `CatEquiv >-> Hom` makes at least one proof in `Homotopy/ExactSequence.v` hang.

Steps to reproduce:
- search and replace `cate_fun'` to `cate_fun` in the `HasEquivs` class declaration in `WildCat/Equiv.v`.
- Comment out the definition of `cate_fun` in `WildCat/Equiv.v`.
- Check the proof marked `@todo` in `Homotopy/ExactSequence.v`

I'm not sure what the problem is yet, but it might just be that using a typeclass method as a coercion doesn't work well enough to bother with. I'll see if I can't minimize a bug or find a fix still, though.

